### PR TITLE
Use the reg command to import/export properties

### DIFF
--- a/xkeymacs/profile.cpp
+++ b/xkeymacs/profile.cpp
@@ -528,8 +528,8 @@ void CProfile::ImportProperties()
 	CFileDialog oFileOpenDialog(TRUE, _T("reg"), _T("xkeymacs"), OFN_HIDEREADONLY | OFN_OVERWRITEPROMPT, CString(MAKEINTRESOURCE(IDS_REGISTRATION_FILTER)));
 	if (oFileOpenDialog.DoModal() == IDOK) {
 		CString szCommandLine;
-		szCommandLine.Format(_T("regedit \"%s\""), oFileOpenDialog.GetPathName());
-		CUtils::Run(szCommandLine, TRUE);	// regedit "x:\xkeymacs.reg"
+		szCommandLine.Format(_T("reg import \"%s\""), oFileOpenDialog.GetPathName());
+		CUtils::Run(szCommandLine, TRUE, TRUE);	// reg import "x:\xkeymacs.reg"
 	}
 
 	DiableTokenPrivileges();
@@ -545,8 +545,8 @@ void CProfile::ExportProperties()
 	CFileDialog oFileOpenDialog(FALSE, _T("reg"), _T("xkeymacs"), OFN_HIDEREADONLY | OFN_OVERWRITEPROMPT, CString(MAKEINTRESOURCE(IDS_REGISTRATION_FILTER)));
 	if (oFileOpenDialog.DoModal() == IDOK) {
 		CString szCommandLine;
-		szCommandLine.Format(_T("regedit /e \"%s\" HKEY_CURRENT_USER\\%s"), oFileOpenDialog.GetPathName(), CString(MAKEINTRESOURCE(IDS_REGSUBKEY_DATA)));
-		CUtils::Run(szCommandLine, TRUE);	// regedit /e "x:\xkeymacs.reg" HKEY_CURRENT_USER\Software\Oishi\XKeymacs2
+		szCommandLine.Format(_T("reg export HKEY_CURRENT_USER\\%s \"%s\" /y"), CString(MAKEINTRESOURCE(IDS_REGSUBKEY_DATA)), oFileOpenDialog.GetPathName());
+		CUtils::Run(szCommandLine, TRUE, TRUE);	// reg export HKEY_CURRENT_USER\Software\Oishi\XKeymacs2 "x:\xkeymacs.reg" /y
 	}
 
 	DiableTokenPrivileges();

--- a/xkeymacsdll/Utils.cpp
+++ b/xkeymacsdll/Utils.cpp
@@ -676,11 +676,15 @@ BOOL CUtils::IsBorlandCppBuilder()
 	return AppName::Match(_T("bcb.exe"));
 }
 
-BOOL CUtils::Run(CString szCommandLine, BOOL isWait)
+BOOL CUtils::Run(CString szCommandLine, BOOL isWait, BOOL isHide)
 {
 	STARTUPINFO si;
 	ZeroMemory(&si, sizeof(si));
 	si.cb = sizeof(si);
+	if (isHide) {
+		si.dwFlags = STARTF_USESHOWWINDOW;
+		si.wShowWindow = SW_HIDE;
+	}
 
 	PROCESS_INFORMATION pi;
 	ZeroMemory(&pi, sizeof(pi));

--- a/xkeymacsdll/Utils.h
+++ b/xkeymacsdll/Utils.h
@@ -25,7 +25,7 @@ public:
 	static BOOL IsVisualSlickEdit();
 	static BOOL IsMSDN();
 	static BOOL IsJavaW();
-	static BOOL Run(CString szCommandLine, BOOL isWait = FALSE);
+	static BOOL Run(CString szCommandLine, BOOL isWait = FALSE, BOOL isHide = FALSE);
 	static BOOL IsBorlandCppBuilder();
 	static BOOL IsLispWorksPersonalEdition();
 	static BOOL IsTeraPad();


### PR DESCRIPTION
The `regedit` command was broken because it requires administrator privileges.
So, changed to the `reg` command.

### NOTE
This code only back up `HKEY_CURRENT_USER\Software\oishi\XKeymacs2`
`HKEY_CURRENT_USER\Software\oishi\XKeymacs` is not backed up.
So, backups should be targeted to `HKEY_CURRENT_USER\Software\oishi`.
(I did not know, so I have not fixed this)